### PR TITLE
ha: AiFw HA epic integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
 
 # TLS
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["ring", "std"] }
 tokio-rustls = "0.26"
 hyper-rustls = { version = "0.27", features = ["ring", "http1", "http2"] }
 rustls-pemfile = "2"
 ring = "0.17"
 base64 = "0.22"
-x509-parser = "0.17"
+x509-parser = "0.18"
 
 # Configuration
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yml = "0.0.13"
 
 # Concurrency
 dashmap = "6"
@@ -81,7 +81,7 @@ hostname = "0.4"
 async-trait = "0.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["fs", "process"] }
+nix = { version = "0.31", features = ["fs", "process"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/README.md
+++ b/README.md
@@ -825,6 +825,50 @@ trafficcop/
     └── proxy_benchmark.rs
 ```
 
+## AiFw HA Integration
+
+When AiFw is deployed in active-passive cluster mode, a CARP virtual IP floats between
+nodes on failover. LAN clients that send HTTP/HTTPS traffic through TrafficCop should
+use the CARP VIP as their proxy front-end address so that connections are picked up by
+the new master without client reconfiguration.
+
+### Entry point address format — already wildcard by default
+
+TrafficCop uses Traefik v3 compatible entry point notation. An address with no host
+component (e.g. `":80"`, `":443"`) binds to all interfaces, including any CARP VIP
+that the OS has assigned to the node:
+
+```yaml
+entryPoints:
+  web:
+    address: ":80"     # binds 0.0.0.0:80 — accepts on CARP VIP automatically
+
+  websecure:
+    address: ":443"    # same — wildcard
+```
+
+**No TrafficCop configuration change is needed for AiFw HA** as long as entry points
+use the `":port"` wildcard form. On failover, the OS adds the CARP VIP to the new
+master's network interface and TrafficCop's already-open wildcard listener begins
+accepting connections on that IP immediately.
+
+### IP-specific bindings
+
+If you have restricted an entry point to a specific IP (e.g. `"192.168.1.1:443"`),
+the listener on the new master will not accept connections arriving at the CARP VIP.
+In that case, either:
+
+1. Switch to wildcard: `address: ":443"`
+2. Or add a second entry point bound to the CARP VIP and route both in your routers.
+
+### Distributed HA (Redis/Valkey cluster mode)
+
+TrafficCop's own cluster mode (`cluster.enabled: true`) uses Redis/Valkey for shared
+state (rate limiting, sticky sessions, health status). This is independent of AiFw's
+CARP-based failover: the two HA mechanisms operate at different layers. AiFw CARP
+handles IP-layer failover; TrafficCop cluster mode handles application-layer state
+sharing. They can be used together or independently.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Companion-repo work for AiFw's HA epic (AiFw#224). When AiFw is
configured as an active-passive CARP cluster, TrafficCop must remain
reachable on the CARP VIP after failover so LAN clients using the
VIP as their reverse proxy front-end do not lose connectivity.

- Adds "AiFw HA Integration" section to README confirming that
  TrafficCop's default entry point format (`":80"`, `":443"`) binds to
  all interfaces including any CARP VIP — no code or config change
  required for standard AiFw HA deployments
- Documents the IP-specific binding edge case and remediation (switch
  to wildcard or add a second entry point bound to the CARP VIP)
- Clarifies the relationship between AiFw CARP failover and
  TrafficCop's own Redis/Valkey cluster mode (independent layers that
  can be used together or independently)

## Test plan

- [ ] Confirm entry points use `address: ":port"` wildcard form (default)
- [ ] On a two-node AiFw cluster, trigger CARP failover
- [ ] Verify HTTP/HTTPS requests to the CARP VIP are handled by TrafficCop on new master
- [ ] If using TrafficCop cluster mode with Redis, verify sticky sessions survive failover