### PR TITLE
fix: remove useless .into() on Errno in single_instance.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trafficcop"
-version = "1.4.7"
+version = "1.4.8"
 edition = "2024"
 authors = ["Zeros and Ones LLC <support@zerosandones.us>"]
 description = "TrafficCop Traffic Manager - High-performance reverse proxy and load balancer"

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -88,7 +88,7 @@ pub fn acquire_at(path: &Path) -> Result<InstanceLock, InstanceLockError> {
             let pid: i32 = buf.trim().parse().unwrap_or(0);
             return Err(InstanceLockError::AlreadyRunning(pid));
         }
-        return Err(InstanceLockError::LockFailed(errno.into()));
+        return Err(InstanceLockError::LockFailed(errno));
     }
 
     // Write our PID for diagnostics. Truncate first so a smaller PID (e.g.


### PR DESCRIPTION
## Summary
Removes a `clippy::useless_conversion` warning at `src/single_instance.rs:91`. `nix::Error` is an alias for `nix::errno::Errno`, so `errno.into()` was converting a type to itself — a no-op.

## Changes
- Drop the redundant `.into()` so the lib builds warning-free
- Bump version to v1.4.8

## Testing
- `cargo check` clean
- `cargo clippy --lib --bins`: `useless_conversion` warning gone
- Full suite previously verified green (199 tests, release build, `cargo package` dry-run) ahead of crates.io publish

Closes #38