### PR TITLE
chore: update dependencies to latest stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trafficcop"
-version = "1.4.8"
+version = "1.4.9"
 edition = "2024"
 authors = ["Zeros and Ones LLC <support@zerosandones.us>"]
 description = "TrafficCop Traffic Manager - High-performance reverse proxy and load balancer"


### PR DESCRIPTION
Updates all Cargo dependencies to their latest stable versions (no pre-release/rc).

- Ran `cargo update` — 29 packages refreshed, all within existing semver constraints.
- `cargo check` passes clean.
- Bumped crate version 1.4.8 → 1.4.9.

Note: `Cargo.lock` is gitignored in this repo, so the refreshed lockfile is not part of this diff — the commit contains only the version bump. No direct dependency required a major-version bump in `Cargo.toml`.

Closes #40